### PR TITLE
feat(currency): add SOL as supported donation currency

### DIFF
--- a/internal/controller/transaction_controller.go
+++ b/internal/controller/transaction_controller.go
@@ -56,7 +56,7 @@ func (c *TransactionController) Create(ctx *gin.Context) {
 			}
 		}
 		if !valid {
-			middleware.AbortWithError(ctx, apperrors.NewValidationError("currency must be one of: ETH, USDT, USDC", nil))
+			middleware.AbortWithError(ctx, apperrors.NewValidationError("currency must be one of: ETH, SOL, USDT, USDC", nil))
 			return
 		}
 	}

--- a/internal/dto/auth_requests.go
+++ b/internal/dto/auth_requests.go
@@ -24,7 +24,7 @@ type TransactionRequest struct {
 	Message     string         `json:"message"`
 	TxHash      string         `json:"tx_hash" validate:"required"`
 	AddressFrom string         `json:"address_from" validate:"required"`
-	Currency    utils.Currency `json:"currency" validate:"omitempty,oneof=ETH USDT USDC"`
+	Currency    utils.Currency `json:"currency" validate:"omitempty,oneof=ETH SOL USDT USDC"`
 }
 
 type RefreshTokenRequest struct {

--- a/internal/model/transaction.go
+++ b/internal/model/transaction.go
@@ -12,7 +12,7 @@ type TransactionRequest struct {
 	Message     string         `json:"message"`
 	TxHash      string         `json:"tx_hash" validate:"required"`
 	AddressFrom string         `json:"address_from" validate:"required"`
-	Currency    utils.Currency `json:"currency" validate:"omitempty,oneof=ETH USDT USDC"`
+	Currency    utils.Currency `json:"currency" validate:"omitempty,oneof=ETH SOL USDT USDC"`
 }
 
 type Transaction struct {

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -13,12 +13,13 @@ const (
 	PhantomWalletProvider  WalletProvider   = "phantom"
 
 	CurrencyETH  Currency = "ETH"
+	CurrencySOL  Currency = "SOL"
 	CurrencyUSDT Currency = "USDT"
 	CurrencyUSDC Currency = "USDC"
 )
 
 // SupportedCurrencies lists currencies accepted for donations (native + stablecoins).
-var SupportedCurrencies = []Currency{CurrencyETH, CurrencyUSDT, CurrencyUSDC}
+var SupportedCurrencies = []Currency{CurrencyETH, CurrencySOL, CurrencyUSDT, CurrencyUSDC}
 
 type ProviderUser struct {
 	ID    string


### PR DESCRIPTION
## Summary
- Add `CurrencySOL = "SOL"` constant to `utils/constants.go` and include in `SupportedCurrencies` slice
- Extend `TransactionRequest.Currency` validation tag from `oneof=ETH USDT USDC` to `oneof=ETH SOL USDT USDC`

## Why
Phantom wallets send SOL on-chain. Without this change, the backend either rejects `currency: "SOL"` requests or silently stores them as ETH. This enables correct currency labelling for Solana donations.

## Notes
- No DB migration needed — `currency` column is `varchar(10)` with no check constraint
- `omitempty` on the field means requests without currency still default to ETH (backwards compatible)