### PR TITLE
fix(websocket): origin validation and duplicate route removal

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -44,9 +44,6 @@ func SetupRouter(c *Container) *gin.Engine {
 
 	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
-	// WebSocket route for OBS alerts
-	router.GET("/ws/streamer/:streamer_id", c.Controllers.Websocket.HandleConnection)
-
 	return router
 }
 

--- a/internal/controller/websocket_controller.go
+++ b/internal/controller/websocket_controller.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"net/http"
+	"os"
+	"strings"
 
 	apperrors "github.com/Dnreikronos/givememoney.fun-backend/internal/errors"
 	"github.com/Dnreikronos/givememoney.fun-backend/internal/middleware"
@@ -12,7 +14,28 @@ import (
 )
 
 var upgrader = ws.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin: func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		// OBS Studio and other desktop clients don't send Origin — allow them
+		if origin == "" {
+			return true
+		}
+		// Allow the configured frontend URL
+		frontendURL := os.Getenv("FRONTEND_URL")
+		if frontendURL == "" {
+			frontendURL = "http://localhost:3000"
+		}
+		if origin == frontendURL {
+			return true
+		}
+		// Allow any localhost / 127.0.0.1 origin for local development
+		if strings.HasPrefix(origin, "http://localhost:") ||
+			strings.HasPrefix(origin, "http://127.0.0.1:") ||
+			strings.HasPrefix(origin, "https://localhost:") {
+			return true
+		}
+		return false
+	},
 }
 
 // WebsocketController handles WebSocket connections for real-time updates.

--- a/internal/controller/websocket_controller.go
+++ b/internal/controller/websocket_controller.go
@@ -13,28 +13,30 @@ import (
 	ws "github.com/gorilla/websocket"
 )
 
+func isAllowedOrigin(origin, frontendURL string) bool {
+	// OBS Studio and other desktop clients don't send Origin — allow them
+	if origin == "" {
+		return true
+	}
+	// Allow the configured frontend URL (exact match)
+	if origin == frontendURL {
+		return true
+	}
+	// Allow any localhost / 127.0.0.1 origin for local development
+	return strings.HasPrefix(origin, "http://localhost:") ||
+		strings.HasPrefix(origin, "https://localhost:") ||
+		strings.HasPrefix(origin, "http://127.0.0.1:") ||
+		strings.HasPrefix(origin, "https://127.0.0.1:")
+}
+
 var upgrader = ws.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
 		origin := r.Header.Get("Origin")
-		// OBS Studio and other desktop clients don't send Origin — allow them
-		if origin == "" {
-			return true
-		}
-		// Allow the configured frontend URL
 		frontendURL := os.Getenv("FRONTEND_URL")
 		if frontendURL == "" {
 			frontendURL = "http://localhost:3000"
 		}
-		if origin == frontendURL {
-			return true
-		}
-		// Allow any localhost / 127.0.0.1 origin for local development
-		if strings.HasPrefix(origin, "http://localhost:") ||
-			strings.HasPrefix(origin, "http://127.0.0.1:") ||
-			strings.HasPrefix(origin, "https://localhost:") {
-			return true
-		}
-		return false
+		return isAllowedOrigin(origin, frontendURL)
 	},
 }
 


### PR DESCRIPTION
## Summary

- **WebSocket security:** replaces `CheckOrigin: return true` with proper origin validation — allows OBS (no Origin), configured `FRONTEND_URL`, and localhost for dev; blocks everything else
- **Route cleanup:** removes the duplicate `/ws/streamer/:streamer_id` root-level route; canonical route remains at `/api/ws/alerts/:streamer_id`
- **Refactor:** `isAllowedOrigin` extracted as a named function for testability; `https://127.0.0.1:*` added to the dev allowlist

## CheckOrigin logic

| Origin | Allowed |
|--------|---------|
| (empty — OBS Studio) | ✓ |
| `FRONTEND_URL` exact match | ✓ |
| `http(s)://localhost:*` | ✓ |
| `http(s)://127.0.0.1:*` | ✓ |
| Anything else | ✗ |

## Test plan

- [ ] OBS Studio connecting to `ws://.../api/ws/alerts/:id` — works (no Origin header)
- [ ] Browser WebSocket from the frontend URL — works
- [ ] Request with unknown Origin — rejected (403)
- [ ] Old route `/ws/streamer/:id` — returns 404
- [ ] `go build ./...` passes